### PR TITLE
Add per channel property style access

### DIFF
--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -92,8 +92,8 @@ class MPR121_Channel():
         return self._mpr121.touched() & (1 << self._channel) != 0
 
     @property
-    """The raw touch measurement."""
     def raw_value(self):
+        """The raw touch measurement."""
         return self._mpr121.filtered_data(self._channel)
 
 class MPR121:

--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -107,7 +107,7 @@ class MPR121:
 
     def __getitem__(self, key):
         if key < 0 or key > 11:
-            raise ValueError('Pin must be a value 0-11.')
+            raise IndexError('Pin must be a value 0-11.')
         if self._channels[key] is None:
             self._channels[key] = MPR121_Channel(self, key)
         return self._channels[key]

--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -170,7 +170,7 @@ class MPR121:
         # Set the touch and release register value for all the inputs.
         for i in range(12):
             self._write_register_byte(MPR121_TOUCHTH_0 + 2*i, touch)
-            self._write_register_byte(MPR121_RELEASETH_0 + 2*i, release)        
+            self._write_register_byte(MPR121_RELEASETH_0 + 2*i, release)
 
     def filtered_data(self, pin):
         """Return filtered data register value for the provided pin (0-11).

--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -80,15 +80,19 @@ MPR121_SOFTRESET       = const(0x80)
 # pylint: enable=bad-whitespace
 
 class MPR121_Channel():
+    """Helper class to represent a touch channel on the MPR121. Not meant to
+    be used directly."""
     def __init__(self, mpr121, channel):
         self._mpr121 = mpr121
         self._channel = channel
 
     @property
     def value(self):
+        """Whether the touch pad is being touched or not."""
         return self._mpr121.touched() & (1 << self._channel) != 0
 
     @property
+    """The raw touch measurement."""
     def raw_value(self):
         return self._mpr121.filtered_data(self._channel)
 
@@ -110,6 +114,7 @@ class MPR121:
 
     @property
     def touched_pins(self):
+        """A tuple of touched state for all pins."""
         touched = self.touched()
         return tuple([bool(touched >> i & 0x01) for i in range(12)])
 

--- a/examples/mpr121_simpletest.py
+++ b/examples/mpr121_simpletest.py
@@ -22,6 +22,6 @@ while True:
     for i in range(12):
         # Call is_touched and pass it then number of the input.  If it's touched
         # it will return True, otherwise it will return False.
-        if mpr121.is_touched(i):
+        if mpr121[i].value:
             print('Input {} touched!'.format(i))
     time.sleep(0.25)  # Small delay to keep from spamming output messages.


### PR DESCRIPTION
A nominal "fix" for #1. Adds per channel property style access to `value` and `raw_value` for each channel:
```python
mpr121[0].value
mpr121[0].raw_value
```