### PR TITLE
Add Stop Mode to register write.

### DIFF
--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -120,8 +120,16 @@ class MPR121:
 
     def _write_register_byte(self, register, value):
         # Write a byte value to the specifier register address.
+        # MPR121 must be put in Stop Mode to write to most registers
+        stop_required = True
+        if register == MPR121_ECR or 0x73 <= register <= 0x7A:
+            stop_required = False
         with self._i2c:
+            if stop_required:
+                self._i2c.write(bytes([MPR121_ECR, 0x00]))
             self._i2c.write(bytes([register, value]))
+            if stop_required:
+                self._i2c.write(bytes([MPR121_ECR, 0x8F]))
 
     def _read_register_bytes(self, register, result, length=None):
         # Read the specified register address and fill the specified result byte


### PR DESCRIPTION
This is a simple fix for #11 . It works but adds extra traffic to I2C register writes. Not sure if it's worth trying to make this fancier? Be able to set mode and then check it in `_write_register_byte`?

Demo of it working:
```python
Adafruit CircuitPython 3.0.3 on 2018-10-10; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import board, busio
>>> import adafruit_mpr121
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> mpr121 = adafruit_mpr121.MPR121(i2c)
>>> buf = bytearray(1)
>>> mpr121._read_register_bytes(0x41, buf)  # read ELE0 Touch Threshold
>>> buf
bytearray(b'\x0c')
>>> mpr121.set_thresholds(0xFF, 0x00)  # try to change it to 0xFF
>>> mpr121._read_register_bytes(0x41, buf)  # read ELE0 Touch Threshold
>>> buf
bytearray(b'\xff')
>>> 
```