### PR TITLE
Add property style access to thresholds

### DIFF
--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -96,6 +96,19 @@ class MPR121_Channel():
         """The raw touch measurement."""
         return self._mpr121.filtered_data(self._channel)
 
+    @property
+    def thresholds(self):
+        """The touch / release threholds."""
+        buf = bytearray(2)
+        self._mpr121._read_register_bytes(MPR121_TOUCHTH_0 + 2*self._channel, buf, 2)
+        return (buf[0], buf[1])
+
+    @thresholds.setter
+    def thresholds(self, value):
+        touch, release = value
+        self._mpr121._write_register_byte(MPR121_TOUCHTH_0 + 2*self._channel, touch)
+        self._mpr121._write_register_byte(MPR121_RELEASETH_0 + 2*self._channel, release)                
+
 class MPR121:
     """Driver for the MPR121 capacitive touch breakout board."""
 
@@ -118,6 +131,18 @@ class MPR121:
         touched = self.touched()
         return tuple([bool(touched >> i & 0x01) for i in range(12)])
 
+    @property
+    def thresholds(self):
+        """The touch / release threholds for all channels."""
+        buf = bytearray(24)
+        self._read_register_bytes(MPR121_TOUCHTH_0, buf, 24)
+        return tuple( [ (buf[2*i], buf[2*i+1]) for i in range(12) ] )
+
+    @thresholds.setter
+    def thresholds(self, value):
+        touch, release = value
+        self.set_thresholds(touch, release)
+        
     def _write_register_byte(self, register, value):
         # Write a byte value to the specifier register address.
         # MPR121 must be put in Stop Mode to write to most registers

--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -102,13 +102,30 @@ class MPR121_Channel():
         """The touch / release threholds."""
         buf = bytearray(2)
         self._mpr121._read_register_bytes(MPR121_TOUCHTH_0 + 2*self._channel, buf, 2)
-        return (buf[0], buf[1])
+        return buf[0], buf[1]
 
     @thresholds.setter
     def thresholds(self, value):
         touch, release = value
         self._mpr121._write_register_byte(MPR121_TOUCHTH_0 + 2*self._channel, touch)
         self._mpr121._write_register_byte(MPR121_RELEASETH_0 + 2*self._channel, release)
+
+    @property
+    def threshold(self):
+        return self.thresholds[0]
+
+    @threshold.setter
+    def threshold(self, value):
+        self._mpr121._write_register_byte(MPR121_TOUCHTH_0 + 2*self._channel, value)
+    
+    @property
+    def release_threshold(self):
+        return self.thresholds[1]
+
+    @release_threshold.setter
+    def release_threshold(self, value):
+        self._mpr121._write_register_byte(MPR121_RELEASETH_0 + 2*self._channel, value)
+
 
 class MPR121:
     """Driver for the MPR121 capacitive touch breakout board."""
@@ -131,18 +148,6 @@ class MPR121:
         """A tuple of touched state for all pins."""
         touched = self.touched()
         return tuple([bool(touched >> i & 0x01) for i in range(12)])
-
-    @property
-    def thresholds(self):
-        """The touch / release threholds for all channels."""
-        buf = bytearray(24)
-        self._read_register_bytes(MPR121_TOUCHTH_0, buf, 24)
-        return tuple([(buf[2*i], buf[2*i+1]) for i in range(12)])
-
-    @thresholds.setter
-    def thresholds(self, value):
-        touch, release = value
-        self.set_thresholds(touch, release)
 
     def _write_register_byte(self, register, value):
         # Write a byte value to the specifier register address.

--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -80,6 +80,7 @@ MPR121_SOFTRESET       = const(0x80)
 # pylint: enable=bad-whitespace
 
 class MPR121_Channel():
+    # pylint: disable=protected-access
     """Helper class to represent a touch channel on the MPR121. Not meant to
     be used directly."""
     def __init__(self, mpr121, channel):
@@ -107,7 +108,7 @@ class MPR121_Channel():
     def thresholds(self, value):
         touch, release = value
         self._mpr121._write_register_byte(MPR121_TOUCHTH_0 + 2*self._channel, touch)
-        self._mpr121._write_register_byte(MPR121_RELEASETH_0 + 2*self._channel, release)                
+        self._mpr121._write_register_byte(MPR121_RELEASETH_0 + 2*self._channel, release)
 
 class MPR121:
     """Driver for the MPR121 capacitive touch breakout board."""
@@ -136,13 +137,13 @@ class MPR121:
         """The touch / release threholds for all channels."""
         buf = bytearray(24)
         self._read_register_bytes(MPR121_TOUCHTH_0, buf, 24)
-        return tuple( [ (buf[2*i], buf[2*i+1]) for i in range(12) ] )
+        return tuple([(buf[2*i], buf[2*i+1]) for i in range(12)])
 
     @thresholds.setter
     def thresholds(self, value):
         touch, release = value
         self.set_thresholds(touch, release)
-        
+
     def _write_register_byte(self, register, value):
         # Write a byte value to the specifier register address.
         # MPR121 must be put in Stop Mode to write to most registers

--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -112,14 +112,16 @@ class MPR121_Channel():
 
     @property
     def threshold(self):
+        """The touch threhold."""
         return self.thresholds[0]
 
     @threshold.setter
     def threshold(self, value):
         self._mpr121._write_register_byte(MPR121_TOUCHTH_0 + 2*self._channel, value)
-    
+
     @property
     def release_threshold(self):
+        """The release threhold."""
         return self.thresholds[1]
 
     @release_threshold.setter

--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -99,7 +99,7 @@ class MPR121_Channel():
 
     @property
     def thresholds(self):
-        """The touch / release threholds."""
+        """The touch / release thresholds."""
         buf = bytearray(2)
         self._mpr121._read_register_bytes(MPR121_TOUCHTH_0 + 2*self._channel, buf, 2)
         return buf[0], buf[1]
@@ -112,7 +112,7 @@ class MPR121_Channel():
 
     @property
     def threshold(self):
-        """The touch threhold."""
+        """The touch threshold."""
         return self.thresholds[0]
 
     @threshold.setter
@@ -121,7 +121,7 @@ class MPR121_Channel():
 
     @property
     def release_threshold(self):
-        """The release threhold."""
+        """The release threshold."""
         return self.thresholds[1]
 
     @release_threshold.setter


### PR DESCRIPTION
Fix for #12.

Kept it pretty simple. You either pass in a tuple or get a tuple of `(touch, release)` threshold values. Can be done for all channels:
```python
>>> mpr.thresholds = (24, 8)
>>> mpr.thresholds
((24, 8), (24, 8), (24, 8), (24, 8), (24, 8), (24, 8), (24, 8), (24, 8), (24, 8), (24, 8), (24, 8), (24, 8))
>>> 
```
or per channel:
```python
>>> mpr[3].thresholds = (12, 6)
>>> mpr[3].thresholds
(12, 6)
>>> 
```