### PR TITLE
Fix GitHub repository details to correct URL.

### DIFF
--- a/adafruit_mpr121.py
+++ b/adafruit_mpr121.py
@@ -37,7 +37,7 @@ import adafruit_bus_device.i2c_device as i2c_device
 from micropython import const
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_VL53L0X.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MPR121.git"
 
 # Register addresses.  Unused registers commented out to save memory.
 # pylint: disable=bad-whitespace


### PR DESCRIPTION
What the title says. This change is needed so the new `circup` utility can work correctly with this module (see: https://github.com/ntoll/circup).

If you've any questions, please don't hesitate to ask. Thank you!

cc/@ladyada